### PR TITLE
sdm845-common: Enable subsystem restart

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -69,3 +69,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.netmgrd.qos.enable=true \
     persist.data.wda.enable=true \
     persist.rmnet.data.enable=true
+
+# SSR
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.sys.ssr.restart_level=ALL_ENABLE


### PR DESCRIPTION
* This is a failsafe to recover critical services
  running on the hexagon CPU ( eg. modem )

Change-Id: Ib54c39fb9d66d8498f68d64666a2d345b9252f1c